### PR TITLE
Add support for templating syslog lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ vet:
 
 test:
 	@echo ">> testing code"
-	@$(GO) test $(pkgs)
+	@$(GO) test -v $(pkgs)
+
+bench:
+	@$(GO) test -v -bench=. $(pkgs)
 
 build: promu
 	@echo ">> building binaries"

--- a/README.md
+++ b/README.md
@@ -131,6 +131,29 @@ The `syslog` input has three parameters:
 - `input.syslog.listenfamily` (Required): The address family of the server. Valid values depend on platform, but include `tcp` and `udp`. On Linux and certain other systems, `unix` is also available.
 - `input.syslog.listenaddr` (Required): The listen specification, for example `:1514` to listen on all interfaces on port 1514.
 - `input.syslog.format` (Optional, default `autodetect`): The format of the syslog messages. Defaults to automatic detection, can also be set to `rfc3164`, `rfc5424` or `rfc6587`.
+- `input.syslog.linetemplate` (Optional, default `[message][content]`): The template to use to for lines passed to the pattern matcher. `[]`-delimited words are substituted with the corresponding fields from the syslog message. Non-existing fields will be ignored. The following fields are available:
+
+   All formats:
+   - `client`
+   - `facility`
+   - `hostname`
+   - `priority`
+   - `severity`
+   - `timestamp`
+   - `tls_peer`
+
+   RFC3164 only:
+   - `content`
+   - `tag`
+
+   RFC5424 only:
+   - `app_name`
+   - `message`
+   - `msg_id`
+   - `proc_id`
+   - `version`
+
+   Since non-existing fields are ignored, the pattern `[message][content]` will contain the main part of the line regardless of which format is used.
 
 ## Named pipe
 Creates a named pipe to which lines can be written. Only available on Linux.

--- a/exporter.go
+++ b/exporter.go
@@ -124,6 +124,7 @@ func main() {
 				done = true
 				break
 			}
+			log.Debugf("Got line %q", line)
 			for _, m := range metrics {
 				t := time.Now()
 				m.MatchLine(line)

--- a/input/syslog.go
+++ b/input/syslog.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 
 	"github.com/prometheus/common/log"
+	"github.com/valyala/fasttemplate"
 	"gopkg.in/mcuadros/go-syslog.v2"
 	"gopkg.in/mcuadros/go-syslog.v2/format"
 )
@@ -14,12 +16,14 @@ type SyslogInput struct {
 	listenAddr   string
 	listenFamily string
 	format       format.Format
+	template     *fasttemplate.Template
 }
 
 var (
 	syslogListenFamily = flag.String("input.syslog.listenfamily", "", "Listening protocol family (tcp/udp/unix)")
 	syslogListenAddr   = flag.String("input.syslog.listenaddr", "", "Listening address of syslog server")
 	syslogFormatFlag   = flag.String("input.syslog.format", "autodetect", "Format of incoming syslog data (rfc3164/rfc5424/rfc6587/autodetect)")
+	syslogLineTemplate = flag.String("input.syslog.linetemplate", "[message][content]", "Template for data to pass to pattern matcher")
 )
 
 func init() {
@@ -57,6 +61,7 @@ func newSyslogInput() (StreamInput, error) {
 		listenAddr:   *syslogListenAddr,
 		listenFamily: *syslogListenFamily,
 		format:       syslogFormat,
+		template:     fasttemplate.New(*syslogLineTemplate, "[", "]"),
 	}, nil
 }
 
@@ -92,23 +97,27 @@ func (input SyslogInput) StartStream(ch chan<- string) {
 
 	go func(lineIn syslog.LogPartsChannel) {
 		for parts := range lineIn {
-			ch <- fmt.Sprintf("%v", parts["content"])
-			/* parts is a map with the following keys:
-			-hostname
-			-tag
-			-content (Message part)
-			-facility
-			-tls_peer
-			-timestamp
-			-severity
-			-client
-			-priority
-			Should these be joined up? Should it be possible to ask for a particular field? User-specified Sprintf-format?
-			For now, just send the message itself.
-			*/
+			line := input.template.ExecuteFuncString(func(w io.Writer, tag string) (int, error) { return tmplTagFunc(w, tag, parts) })
+			ch <- line
 		}
 	}(syslogChannel)
 
 	server.Wait()
 	log.Info("Syslog server shutting down")
+}
+
+func tmplTagFunc(w io.Writer, tag string, m map[string]interface{}) (int, error) {
+	v := m[tag]
+	if v == nil {
+		return 0, nil
+	}
+	switch value := v.(type) {
+	case []byte:
+		return w.Write(value)
+	case string:
+		return w.Write([]byte(value))
+	default:
+		// TODO: Performance test
+		return w.Write([]byte(fmt.Sprintf("%v", v)))
+	}
 }

--- a/input/syslog_test.go
+++ b/input/syslog_test.go
@@ -1,0 +1,54 @@
+package input
+
+import (
+	"testing"
+	"time"
+
+	"github.com/valyala/fasttemplate"
+	"gopkg.in/mcuadros/go-syslog.v2/format"
+)
+
+var testMessages = []map[string]interface{}{
+	{
+		"string1": "hello",
+		"int":     13,
+		"string2": "longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong",
+		"time":    time.Now(),
+	},
+	{
+		"string1": "both-longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong",
+		"int":     61,
+		"string2": "longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong",
+		"time":    time.Now(),
+	},
+	{
+		"string1": "only-string1",
+		"int":     123718,
+		"time":    time.Now(),
+	},
+	{
+		"int":     0,
+		"string2": "only-string2",
+		"time":    time.Now(),
+	},
+	{
+		"string1": "hello",
+		"int":     -1541,
+		"string2": "world",
+	},
+}
+
+func BenchmarkMessageHandler(b *testing.B) {
+	t := fasttemplate.New("[string1][int][string2][time]", "[", "]")
+	ch := make(chan string, b.N)
+	logPartCh := make(chan format.LogParts, b.N)
+
+	for n := 0; n < b.N; n++ {
+		logPartCh <- testMessages[n%len(testMessages)]
+	}
+	close(logPartCh)
+
+	for n := 0; n < b.N; n++ {
+		messageHandler(t, ch, logPartCh)
+	}
+}

--- a/vendor/github.com/valyala/bytebufferpool/LICENSE
+++ b/vendor/github.com/valyala/bytebufferpool/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Aliaksandr Valialkin, VertaMedia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/valyala/bytebufferpool/README.md
+++ b/vendor/github.com/valyala/bytebufferpool/README.md
@@ -1,0 +1,21 @@
+[![Build Status](https://travis-ci.org/valyala/bytebufferpool.svg)](https://travis-ci.org/valyala/bytebufferpool)
+[![GoDoc](https://godoc.org/github.com/valyala/bytebufferpool?status.svg)](http://godoc.org/github.com/valyala/bytebufferpool)
+[![Go Report](http://goreportcard.com/badge/valyala/bytebufferpool)](http://goreportcard.com/report/valyala/bytebufferpool)
+
+# bytebufferpool
+
+An implementation of a pool of byte buffers with anti-memory-waste protection.
+
+The pool may waste limited amount of memory due to fragmentation.
+This amount equals to the maximum total size of the byte buffers
+in concurrent use.
+
+# Benchmark results
+Currently bytebufferpool is fastest and most effective buffer pool written in Go.
+
+You can find results [here](https://omgnull.github.io/go-benchmark/buffer/).
+
+# bytebufferpool users
+
+* [fasthttp](https://github.com/valyala/fasthttp)
+* [quicktemplate](https://github.com/valyala/quicktemplate)

--- a/vendor/github.com/valyala/bytebufferpool/bytebuffer.go
+++ b/vendor/github.com/valyala/bytebufferpool/bytebuffer.go
@@ -1,0 +1,111 @@
+package bytebufferpool
+
+import "io"
+
+// ByteBuffer provides byte buffer, which can be used for minimizing
+// memory allocations.
+//
+// ByteBuffer may be used with functions appending data to the given []byte
+// slice. See example code for details.
+//
+// Use Get for obtaining an empty byte buffer.
+type ByteBuffer struct {
+
+	// B is a byte buffer to use in append-like workloads.
+	// See example code for details.
+	B []byte
+}
+
+// Len returns the size of the byte buffer.
+func (b *ByteBuffer) Len() int {
+	return len(b.B)
+}
+
+// ReadFrom implements io.ReaderFrom.
+//
+// The function appends all the data read from r to b.
+func (b *ByteBuffer) ReadFrom(r io.Reader) (int64, error) {
+	p := b.B
+	nStart := int64(len(p))
+	nMax := int64(cap(p))
+	n := nStart
+	if nMax == 0 {
+		nMax = 64
+		p = make([]byte, nMax)
+	} else {
+		p = p[:nMax]
+	}
+	for {
+		if n == nMax {
+			nMax *= 2
+			bNew := make([]byte, nMax)
+			copy(bNew, p)
+			p = bNew
+		}
+		nn, err := r.Read(p[n:])
+		n += int64(nn)
+		if err != nil {
+			b.B = p[:n]
+			n -= nStart
+			if err == io.EOF {
+				return n, nil
+			}
+			return n, err
+		}
+	}
+}
+
+// WriteTo implements io.WriterTo.
+func (b *ByteBuffer) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(b.B)
+	return int64(n), err
+}
+
+// Bytes returns b.B, i.e. all the bytes accumulated in the buffer.
+//
+// The purpose of this function is bytes.Buffer compatibility.
+func (b *ByteBuffer) Bytes() []byte {
+	return b.B
+}
+
+// Write implements io.Writer - it appends p to ByteBuffer.B
+func (b *ByteBuffer) Write(p []byte) (int, error) {
+	b.B = append(b.B, p...)
+	return len(p), nil
+}
+
+// WriteByte appends the byte c to the buffer.
+//
+// The purpose of this function is bytes.Buffer compatibility.
+//
+// The function always returns nil.
+func (b *ByteBuffer) WriteByte(c byte) error {
+	b.B = append(b.B, c)
+	return nil
+}
+
+// WriteString appends s to ByteBuffer.B.
+func (b *ByteBuffer) WriteString(s string) (int, error) {
+	b.B = append(b.B, s...)
+	return len(s), nil
+}
+
+// Set sets ByteBuffer.B to p.
+func (b *ByteBuffer) Set(p []byte) {
+	b.B = append(b.B[:0], p...)
+}
+
+// SetString sets ByteBuffer.B to s.
+func (b *ByteBuffer) SetString(s string) {
+	b.B = append(b.B[:0], s...)
+}
+
+// String returns string representation of ByteBuffer.B.
+func (b *ByteBuffer) String() string {
+	return string(b.B)
+}
+
+// Reset makes ByteBuffer.B empty.
+func (b *ByteBuffer) Reset() {
+	b.B = b.B[:0]
+}

--- a/vendor/github.com/valyala/bytebufferpool/doc.go
+++ b/vendor/github.com/valyala/bytebufferpool/doc.go
@@ -1,0 +1,7 @@
+// Package bytebufferpool implements a pool of byte buffers
+// with anti-fragmentation protection.
+//
+// The pool may waste limited amount of memory due to fragmentation.
+// This amount equals to the maximum total size of the byte buffers
+// in concurrent use.
+package bytebufferpool

--- a/vendor/github.com/valyala/bytebufferpool/pool.go
+++ b/vendor/github.com/valyala/bytebufferpool/pool.go
@@ -1,0 +1,151 @@
+package bytebufferpool
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+)
+
+const (
+	minBitSize = 6 // 2**6=64 is a CPU cache line size
+	steps      = 20
+
+	minSize = 1 << minBitSize
+	maxSize = 1 << (minBitSize + steps - 1)
+
+	calibrateCallsThreshold = 42000
+	maxPercentile           = 0.95
+)
+
+// Pool represents byte buffer pool.
+//
+// Distinct pools may be used for distinct types of byte buffers.
+// Properly determined byte buffer types with their own pools may help reducing
+// memory waste.
+type Pool struct {
+	calls       [steps]uint64
+	calibrating uint64
+
+	defaultSize uint64
+	maxSize     uint64
+
+	pool sync.Pool
+}
+
+var defaultPool Pool
+
+// Get returns an empty byte buffer from the pool.
+//
+// Got byte buffer may be returned to the pool via Put call.
+// This reduces the number of memory allocations required for byte buffer
+// management.
+func Get() *ByteBuffer { return defaultPool.Get() }
+
+// Get returns new byte buffer with zero length.
+//
+// The byte buffer may be returned to the pool via Put after the use
+// in order to minimize GC overhead.
+func (p *Pool) Get() *ByteBuffer {
+	v := p.pool.Get()
+	if v != nil {
+		return v.(*ByteBuffer)
+	}
+	return &ByteBuffer{
+		B: make([]byte, 0, atomic.LoadUint64(&p.defaultSize)),
+	}
+}
+
+// Put returns byte buffer to the pool.
+//
+// ByteBuffer.B mustn't be touched after returning it to the pool.
+// Otherwise data races will occur.
+func Put(b *ByteBuffer) { defaultPool.Put(b) }
+
+// Put releases byte buffer obtained via Get to the pool.
+//
+// The buffer mustn't be accessed after returning to the pool.
+func (p *Pool) Put(b *ByteBuffer) {
+	idx := index(len(b.B))
+
+	if atomic.AddUint64(&p.calls[idx], 1) > calibrateCallsThreshold {
+		p.calibrate()
+	}
+
+	maxSize := int(atomic.LoadUint64(&p.maxSize))
+	if maxSize == 0 || cap(b.B) <= maxSize {
+		b.Reset()
+		p.pool.Put(b)
+	}
+}
+
+func (p *Pool) calibrate() {
+	if !atomic.CompareAndSwapUint64(&p.calibrating, 0, 1) {
+		return
+	}
+
+	a := make(callSizes, 0, steps)
+	var callsSum uint64
+	for i := uint64(0); i < steps; i++ {
+		calls := atomic.SwapUint64(&p.calls[i], 0)
+		callsSum += calls
+		a = append(a, callSize{
+			calls: calls,
+			size:  minSize << i,
+		})
+	}
+	sort.Sort(a)
+
+	defaultSize := a[0].size
+	maxSize := defaultSize
+
+	maxSum := uint64(float64(callsSum) * maxPercentile)
+	callsSum = 0
+	for i := 0; i < steps; i++ {
+		if callsSum > maxSum {
+			break
+		}
+		callsSum += a[i].calls
+		size := a[i].size
+		if size > maxSize {
+			maxSize = size
+		}
+	}
+
+	atomic.StoreUint64(&p.defaultSize, defaultSize)
+	atomic.StoreUint64(&p.maxSize, maxSize)
+
+	atomic.StoreUint64(&p.calibrating, 0)
+}
+
+type callSize struct {
+	calls uint64
+	size  uint64
+}
+
+type callSizes []callSize
+
+func (ci callSizes) Len() int {
+	return len(ci)
+}
+
+func (ci callSizes) Less(i, j int) bool {
+	return ci[i].calls > ci[j].calls
+}
+
+func (ci callSizes) Swap(i, j int) {
+	ci[i], ci[j] = ci[j], ci[i]
+}
+
+func index(n int) int {
+	n--
+	n >>= minBitSize
+	idx := 0
+	for n > 0 {
+		n >>= 1
+		idx++
+	}
+	if idx >= steps {
+		idx = steps - 1
+	}
+	return idx
+}

--- a/vendor/github.com/valyala/fasttemplate/LICENSE
+++ b/vendor/github.com/valyala/fasttemplate/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Aliaksandr Valialkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/valyala/fasttemplate/README.md
+++ b/vendor/github.com/valyala/fasttemplate/README.md
@@ -1,0 +1,85 @@
+fasttemplate
+============
+
+Simple and fast template engine for Go.
+
+Fasttemplate peforms only a single task - it substitutes template placeholders
+with user-defined values. At high speed :)
+
+Take a look at [quicktemplate](https://github.com/valyala/quicktemplate) if you  need fast yet powerful html template engine.
+
+*Please note that fasttemplate doesn't do any escaping on template values
+unlike [html/template](http://golang.org/pkg/html/template/) do. So values
+must be properly escaped before passing them to fasttemplate.*
+
+Fasttemplate is faster than [text/template](http://golang.org/pkg/text/template/),
+[strings.Replace](http://golang.org/pkg/strings/#Replace),
+[strings.Replacer](http://golang.org/pkg/strings/#Replacer)
+and [fmt.Fprintf](https://golang.org/pkg/fmt/#Fprintf) on placeholders' substitution.
+
+Below are benchmark results comparing fasttemplate performance to text/template,
+strings.Replace, strings.Replacer and fmt.Fprintf:
+
+```
+$ go test -bench=. -benchmem
+PASS
+BenchmarkFmtFprintf-4                   	 2000000	       790 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStringsReplace-4               	  500000	      3474 ns/op	    2112 B/op	      14 allocs/op
+BenchmarkStringsReplacer-4              	  500000	      2657 ns/op	    2256 B/op	      23 allocs/op
+BenchmarkTextTemplate-4                 	  500000	      3333 ns/op	     336 B/op	      19 allocs/op
+BenchmarkFastTemplateExecuteFunc-4      	 5000000	       349 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFastTemplateExecute-4          	 3000000	       383 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFastTemplateExecuteFuncString-4	 3000000	       549 ns/op	     144 B/op	       1 allocs/op
+BenchmarkFastTemplateExecuteString-4    	 3000000	       572 ns/op	     144 B/op	       1 allocs/op
+BenchmarkFastTemplateExecuteTagFunc-4   	 2000000	       743 ns/op	     144 B/op	       3 allocs/op
+```
+
+
+Docs
+====
+
+See http://godoc.org/github.com/valyala/fasttemplate .
+
+
+Usage
+=====
+
+```go
+	template := "http://{{host}}/?q={{query}}&foo={{bar}}{{bar}}"
+	t := fasttemplate.New(template, "{{", "}}")
+	s := t.ExecuteString(map[string]interface{}{
+		"host":  "google.com",
+		"query": url.QueryEscape("hello=world"),
+		"bar":   "foobar",
+	})
+	fmt.Printf("%s", s)
+
+	// Output:
+	// http://google.com/?q=hello%3Dworld&foo=foobarfoobar
+```
+
+
+Advanced usage
+==============
+
+```go
+	template := "Hello, [user]! You won [prize]!!! [foobar]"
+	t, err := fasttemplate.NewTemplate(template, "[", "]")
+	if err != nil {
+		log.Fatalf("unexpected error when parsing template: %s", err)
+	}
+	s := t.ExecuteFuncString(func(w io.Writer, tag string) (int, error) {
+		switch tag {
+		case "user":
+			return w.Write([]byte("John"))
+		case "prize":
+			return w.Write([]byte("$100500"))
+		default:
+			return w.Write([]byte(fmt.Sprintf("[unknown tag %q]", tag)))
+		}
+	})
+	fmt.Printf("%s", s)
+
+	// Output:
+	// Hello, John! You won $100500!!! [unknown tag "foobar"]
+```

--- a/vendor/github.com/valyala/fasttemplate/template.go
+++ b/vendor/github.com/valyala/fasttemplate/template.go
@@ -1,0 +1,317 @@
+// Package fasttemplate implements simple and fast template library.
+//
+// Fasttemplate is faster than text/template, strings.Replace
+// and strings.Replacer.
+//
+// Fasttemplate ideally fits for fast and simple placeholders' substitutions.
+package fasttemplate
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/valyala/bytebufferpool"
+	"io"
+)
+
+// ExecuteFunc calls f on each template tag (placeholder) occurrence.
+//
+// Returns the number of bytes written to w.
+//
+// This function is optimized for constantly changing templates.
+// Use Template.ExecuteFunc for frozen templates.
+func ExecuteFunc(template, startTag, endTag string, w io.Writer, f TagFunc) (int64, error) {
+	s := unsafeString2Bytes(template)
+	a := unsafeString2Bytes(startTag)
+	b := unsafeString2Bytes(endTag)
+
+	var nn int64
+	var ni int
+	var err error
+	for {
+		n := bytes.Index(s, a)
+		if n < 0 {
+			break
+		}
+		ni, err = w.Write(s[:n])
+		nn += int64(ni)
+		if err != nil {
+			return nn, err
+		}
+
+		s = s[n+len(a):]
+		n = bytes.Index(s, b)
+		if n < 0 {
+			// cannot find end tag - just write it to the output.
+			ni, _ = w.Write(a)
+			nn += int64(ni)
+			break
+		}
+
+		ni, err = f(w, unsafeBytes2String(s[:n]))
+		nn += int64(ni)
+		s = s[n+len(b):]
+	}
+	ni, err = w.Write(s)
+	nn += int64(ni)
+
+	return nn, err
+}
+
+// Execute substitutes template tags (placeholders) with the corresponding
+// values from the map m and writes the result to the given writer w.
+//
+// Substitution map m may contain values with the following types:
+//   * []byte - the fastest value type
+//   * string - convenient value type
+//   * TagFunc - flexible value type
+//
+// Returns the number of bytes written to w.
+//
+// This function is optimized for constantly changing templates.
+// Use Template.Execute for frozen templates.
+func Execute(template, startTag, endTag string, w io.Writer, m map[string]interface{}) (int64, error) {
+	return ExecuteFunc(template, startTag, endTag, w, func(w io.Writer, tag string) (int, error) { return stdTagFunc(w, tag, m) })
+}
+
+// ExecuteFuncString calls f on each template tag (placeholder) occurrence
+// and substitutes it with the data written to TagFunc's w.
+//
+// Returns the resulting string.
+//
+// This function is optimized for constantly changing templates.
+// Use Template.ExecuteFuncString for frozen templates.
+func ExecuteFuncString(template, startTag, endTag string, f TagFunc) string {
+	tagsCount := bytes.Count(unsafeString2Bytes(template), unsafeString2Bytes(startTag))
+	if tagsCount == 0 {
+		return template
+	}
+
+	bb := byteBufferPool.Get()
+	if _, err := ExecuteFunc(template, startTag, endTag, bb, f); err != nil {
+		panic(fmt.Sprintf("unexpected error: %s", err))
+	}
+	s := string(bb.B)
+	bb.Reset()
+	byteBufferPool.Put(bb)
+	return s
+}
+
+var byteBufferPool bytebufferpool.Pool
+
+// ExecuteString substitutes template tags (placeholders) with the corresponding
+// values from the map m and returns the result.
+//
+// Substitution map m may contain values with the following types:
+//   * []byte - the fastest value type
+//   * string - convenient value type
+//   * TagFunc - flexible value type
+//
+// This function is optimized for constantly changing templates.
+// Use Template.ExecuteString for frozen templates.
+func ExecuteString(template, startTag, endTag string, m map[string]interface{}) string {
+	return ExecuteFuncString(template, startTag, endTag, func(w io.Writer, tag string) (int, error) { return stdTagFunc(w, tag, m) })
+}
+
+// Template implements simple template engine, which can be used for fast
+// tags' (aka placeholders) substitution.
+type Template struct {
+	template string
+	startTag string
+	endTag   string
+
+	texts          [][]byte
+	tags           []string
+	byteBufferPool bytebufferpool.Pool
+}
+
+// New parses the given template using the given startTag and endTag
+// as tag start and tag end.
+//
+// The returned template can be executed by concurrently running goroutines
+// using Execute* methods.
+//
+// New panics if the given template cannot be parsed. Use NewTemplate instead
+// if template may contain errors.
+func New(template, startTag, endTag string) *Template {
+	t, err := NewTemplate(template, startTag, endTag)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// NewTemplate parses the given template using the given startTag and endTag
+// as tag start and tag end.
+//
+// The returned template can be executed by concurrently running goroutines
+// using Execute* methods.
+func NewTemplate(template, startTag, endTag string) (*Template, error) {
+	var t Template
+	err := t.Reset(template, startTag, endTag)
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// TagFunc can be used as a substitution value in the map passed to Execute*.
+// Execute* functions pass tag (placeholder) name in 'tag' argument.
+//
+// TagFunc must be safe to call from concurrently running goroutines.
+//
+// TagFunc must write contents to w and return the number of bytes written.
+type TagFunc func(w io.Writer, tag string) (int, error)
+
+// Reset resets the template t to new one defined by
+// template, startTag and endTag.
+//
+// Reset allows Template object re-use.
+//
+// Reset may be called only if no other goroutines call t methods at the moment.
+func (t *Template) Reset(template, startTag, endTag string) error {
+	// Keep these vars in t, so GC won't collect them and won't break
+	// vars derived via unsafe*
+	t.template = template
+	t.startTag = startTag
+	t.endTag = endTag
+	t.texts = t.texts[:0]
+	t.tags = t.tags[:0]
+
+	if len(startTag) == 0 {
+		panic("startTag cannot be empty")
+	}
+	if len(endTag) == 0 {
+		panic("endTag cannot be empty")
+	}
+
+	s := unsafeString2Bytes(template)
+	a := unsafeString2Bytes(startTag)
+	b := unsafeString2Bytes(endTag)
+
+	tagsCount := bytes.Count(s, a)
+	if tagsCount == 0 {
+		return nil
+	}
+
+	if tagsCount+1 > cap(t.texts) {
+		t.texts = make([][]byte, 0, tagsCount+1)
+	}
+	if tagsCount > cap(t.tags) {
+		t.tags = make([]string, 0, tagsCount)
+	}
+
+	for {
+		n := bytes.Index(s, a)
+		if n < 0 {
+			t.texts = append(t.texts, s)
+			break
+		}
+		t.texts = append(t.texts, s[:n])
+
+		s = s[n+len(a):]
+		n = bytes.Index(s, b)
+		if n < 0 {
+			return fmt.Errorf("Cannot find end tag=%q in the template=%q starting from %q", endTag, template, s)
+		}
+
+		t.tags = append(t.tags, unsafeBytes2String(s[:n]))
+		s = s[n+len(b):]
+	}
+
+	return nil
+}
+
+// ExecuteFunc calls f on each template tag (placeholder) occurrence.
+//
+// Returns the number of bytes written to w.
+//
+// This function is optimized for frozen templates.
+// Use ExecuteFunc for constantly changing templates.
+func (t *Template) ExecuteFunc(w io.Writer, f TagFunc) (int64, error) {
+	var nn int64
+
+	n := len(t.texts) - 1
+	if n == -1 {
+		ni, err := w.Write(unsafeString2Bytes(t.template))
+		return int64(ni), err
+	}
+
+	for i := 0; i < n; i++ {
+		ni, err := w.Write(t.texts[i])
+		nn += int64(ni)
+		if err != nil {
+			return nn, err
+		}
+
+		ni, err = f(w, t.tags[i])
+		nn += int64(ni)
+		if err != nil {
+			return nn, err
+		}
+	}
+	ni, err := w.Write(t.texts[n])
+	nn += int64(ni)
+	return nn, err
+}
+
+// Execute substitutes template tags (placeholders) with the corresponding
+// values from the map m and writes the result to the given writer w.
+//
+// Substitution map m may contain values with the following types:
+//   * []byte - the fastest value type
+//   * string - convenient value type
+//   * TagFunc - flexible value type
+//
+// Returns the number of bytes written to w.
+func (t *Template) Execute(w io.Writer, m map[string]interface{}) (int64, error) {
+	return t.ExecuteFunc(w, func(w io.Writer, tag string) (int, error) { return stdTagFunc(w, tag, m) })
+}
+
+// ExecuteFuncString calls f on each template tag (placeholder) occurrence
+// and substitutes it with the data written to TagFunc's w.
+//
+// Returns the resulting string.
+//
+// This function is optimized for frozen templates.
+// Use ExecuteFuncString for constantly changing templates.
+func (t *Template) ExecuteFuncString(f TagFunc) string {
+	bb := t.byteBufferPool.Get()
+	if _, err := t.ExecuteFunc(bb, f); err != nil {
+		panic(fmt.Sprintf("unexpected error: %s", err))
+	}
+	s := string(bb.Bytes())
+	bb.Reset()
+	t.byteBufferPool.Put(bb)
+	return s
+}
+
+// ExecuteString substitutes template tags (placeholders) with the corresponding
+// values from the map m and returns the result.
+//
+// Substitution map m may contain values with the following types:
+//   * []byte - the fastest value type
+//   * string - convenient value type
+//   * TagFunc - flexible value type
+//
+// This function is optimized for frozen templates.
+// Use ExecuteString for constantly changing templates.
+func (t *Template) ExecuteString(m map[string]interface{}) string {
+	return t.ExecuteFuncString(func(w io.Writer, tag string) (int, error) { return stdTagFunc(w, tag, m) })
+}
+
+func stdTagFunc(w io.Writer, tag string, m map[string]interface{}) (int, error) {
+	v := m[tag]
+	if v == nil {
+		return 0, nil
+	}
+	switch value := v.(type) {
+	case []byte:
+		return w.Write(value)
+	case string:
+		return w.Write([]byte(value))
+	case TagFunc:
+		return value(w, tag)
+	default:
+		panic(fmt.Sprintf("tag=%q contains unexpected value type=%#v. Expected []byte, string or TagFunc", tag, v))
+	}
+}

--- a/vendor/github.com/valyala/fasttemplate/unsafe.go
+++ b/vendor/github.com/valyala/fasttemplate/unsafe.go
@@ -1,0 +1,22 @@
+// +build !appengine
+
+package fasttemplate
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func unsafeBytes2String(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+func unsafeString2Bytes(s string) []byte {
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bh := reflect.SliceHeader{
+		Data: sh.Data,
+		Len:  sh.Len,
+		Cap:  sh.Len,
+	}
+	return *(*[]byte)(unsafe.Pointer(&bh))
+}

--- a/vendor/github.com/valyala/fasttemplate/unsafe_gae.go
+++ b/vendor/github.com/valyala/fasttemplate/unsafe_gae.go
@@ -1,0 +1,11 @@
+// +build appengine
+
+package fasttemplate
+
+func unsafeBytes2String(b []byte) string {
+	return string(b)
+}
+
+func unsafeString2Bytes(s string) []byte {
+	return []byte(s)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,12 +3,6 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "pvV787RyoEIcpfi5G+W92G2nZbc=",
-			"path": "github.com/Sirupsen/logrus",
-			"revision": "5e5dc898656f695e2a086b8e12559febbfc01562",
-			"revisionTime": "2017-05-15T10:45:16Z"
-		},
-		{
 			"checksumSHA1": "0SQcBJ2JD1jEXr5uhmG/RNMa6t0=",
 			"path": "github.com/beorn7/perks/quantile",
 			"revision": "3ac7bf7a47d159a033b107610db8a1b6575507a4",
@@ -109,6 +103,25 @@
 			"path": "github.com/prometheus/procfs",
 			"revision": "abf152e5f3e97f2fafac028d2cc06c1feb87ffa5",
 			"revisionTime": "2016-04-11T19:08:41Z"
+		},
+		{
+			"checksumSHA1": "pvV787RyoEIcpfi5G+W92G2nZbc=",
+			"path": "github.com/sirupsen/logrus",
+			"revision": "5e5dc898656f695e2a086b8e12559febbfc01562",
+			"revisionTime": "2017-05-15T10:45:16Z"
+		},
+		{
+			"checksumSHA1": "LTOa3BADhwvT0wFCknPueQALm8I=",
+			"origin": "github.com/valyala/fasttemplate/vendor/github.com/valyala/bytebufferpool",
+			"path": "github.com/valyala/bytebufferpool",
+			"revision": "dcecefd839c4193db0d35b88ec65b4c12d360ab0",
+			"revisionTime": "2017-02-24T21:24:29Z"
+		},
+		{
+			"checksumSHA1": "gtG8jeB0fcTmKZf+6Vbcoa6nfec=",
+			"path": "github.com/valyala/fasttemplate",
+			"revision": "dcecefd839c4193db0d35b88ec65b4c12d360ab0",
+			"revisionTime": "2017-02-24T21:24:29Z"
 		},
 		{
 			"checksumSHA1": "rPV8+049OOLKJLcGhi5dNQ1yvBA=",


### PR DESCRIPTION
This PR adds support for using more than the `content` fields in the syslog matcher, which was previously hard-coded. 
A new command line parameter is added, `-input.syslog.linetemplate`, which defaults to `[message][content]`. This default preserves the old behavior for RFC3164 messages, but also ensures RFC5424 works.

This fixes #6. 
@MichaelMayorov, could you confirm this works for you?